### PR TITLE
Fix gradle

### DIFF
--- a/src/platforms/android/include.gradle
+++ b/src/platforms/android/include.gradle
@@ -10,5 +10,5 @@ repositories {
 }
 
 dependencies {
-    compile 'com.github.kenglxn.QRGen:android:2.6.0'
+    implementation 'com.github.kenglxn.QRGen:android:2.6.0'
 }


### PR DESCRIPTION
This is related to latest Android tooling - That plugin can be updated to use the proper syntax here:
https://github.com/erodriguezh/nativescript-qr-generator/blob/develop/src/platforms/android/include.gradle#L13
You may consider submitting a quick pull request to the author to change compile > implementation so it should look like this:

implementation 'com.github.kenglxn.QRGen:android:2.6.0'
Here are some additional references:

https://tomgregory.com/gradle-implementation-vs-compile-dependencies/
https://stackoverflow.com/questions/59455124/compile-is-deprecated-replace-with-implementation
